### PR TITLE
Upgrade AGP to 8.13.2 to support Kotlin 2.3

### DIFF
--- a/Sources/SkipUnit/Skip/skip.yml
+++ b/Sources/SkipUnit/Skip/skip.yml
@@ -40,7 +40,7 @@ settings:
                 - 'version("android-sdk-min", "28")'
                 - 'version("android-sdk-compile", "36")'
 
-                - 'version("android-gradle-plugin", "8.13.0")'
+                - 'version("android-gradle-plugin", "8.13.2")'
                 - 'plugin("android-library", "com.android.library").versionRef("android-gradle-plugin")'
                 - 'plugin("android-application", "com.android.application").versionRef("android-gradle-plugin")'
 


### PR DESCRIPTION
https://developer.android.com/build/kotlin-support says that Kotlin 2.3 requires AGP 8.13.2 or later.

Fixes https://github.com/skiptools/skip/issues/658

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [ ] OPTIONAL: I have tested my change on an iOS simulator or device
- [ ] OPTIONAL: I have tested my change on an Android emulator or device

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Cursor tracked this down for me. The only testing I did was to confirm that https://github.com/skiptools/skip/issues/658 is fixed with it. (It's not at all clear to me how best to regression test AGP upgrades!)