### PR TITLE
Update to android-gradle-plugin 8.13.2

### DIFF
--- a/Sources/SkipUnit/Skip/skip.yml
+++ b/Sources/SkipUnit/Skip/skip.yml
@@ -40,7 +40,10 @@ settings:
                 - 'version("android-sdk-min", "28")'
                 - 'version("android-sdk-compile", "36")'
 
-                - 'version("android-gradle-plugin", "8.13.0")'
+                # keep android-gradle-plugin and kotlin versions in sync according to compatibility table at
+                # https://developer.android.com/build/kotlin-support
+
+                - 'version("android-gradle-plugin", "8.13.2")'
                 - 'plugin("android-library", "com.android.library").versionRef("android-gradle-plugin")'
                 - 'plugin("android-application", "com.android.application").versionRef("android-gradle-plugin")'
 


### PR DESCRIPTION
We need to keep the `android-gradle-plugin` and `kotlin` versions in sync according to compatibility table at https://developer.android.com/build/kotlin-support

This may fix the error reported at https://github.com/skiptools/skip/issues/658:

```
> Task :app:minifyReleaseWithR8
WARNING: R8: An error occurred when parsing kotlin metadata. This normally happens when using a newer version of kotlin than the kotlin version released when this version of R8 was created. To find compatible kotlin versions, please see: https://developer.android.com/studio/build/kotlin-d8-r8-versions
```


