### PR TITLE
Bump asm dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.1
 import PackageDescription
 
 let package = Package(

--- a/Sources/SkipUnit/Skip/skip.yml
+++ b/Sources/SkipUnit/Skip/skip.yml
@@ -75,6 +75,10 @@ settings:
                 - 'version("robolectric", "4.16.1")'
                 - 'library("robolectric", "org.robolectric", "robolectric").versionRef("robolectric")'
 
+                # explicit asm version until https://github.com/robolectric/robolectric/issues/11204
+                - 'version("asm", "9.10")'
+                - 'library("asm", "org.ow2.asm", "asm").versionRef("asm")'
+
 # the blocks to add to the build.gradle.kts
 build:
   contents:
@@ -92,6 +96,7 @@ build:
         - 'api(testLibs.androidx.test.runner)'
         - 'api(testLibs.kotlinx.coroutines.test)'
         - 'api(testLibs.kotlin.test.junit)'
+        - 'testImplementation(testLibs.asm)'
         - 'testImplementation(testLibs.robolectric)'
         - 'testImplementation(testLibs.androidx.test.core)'
         - 'testImplementation(testLibs.androidx.test.rules)'


### PR DESCRIPTION
As reported at https://github.com/robolectric/robolectric/issues/11204, running local tests against Java 26 will raise the exception:

```
java.lang.IllegalArgumentException: Unsupported class file major version 70
	at org.objectweb.asm.ClassReader.<init>(ClassReader.java:200)
	at org.objectweb.asm.ClassReader.<init>(ClassReader.java:180)
	at org.objectweb.asm.ClassReader.<init>(ClassReader.java:166)
	at org.robolectric.internal.bytecode.ClassNodeProvider.createClassNode(ClassNodeProvider.java:24)
	at org.robolectric.internal.bytecode.ClassNodeProvider.getClassNode(ClassNodeProvider.java:16)
	at org.robolectric.internal.bytecode.InstrumentingClassWriter.typeInfo(InstrumentingClassWriter.java:114)
	at org.robolectric.internal.bytecode.InstrumentingClassWriter.getCommonSuperClass(InstrumentingClassWriter.java:36)
	at org.objectweb.asm.SymbolTable.addMergedType(SymbolTable.java:1286)
	at org.objectweb.asm.Frame.merge(Frame.java:1311)
	at org.objectweb.asm.Frame.merge(Frame.java:1218)
	at org.objectweb.asm.MethodWriter.computeAllFrames(MethodWriter.java:1612)
	at org.objectweb.asm.MethodWriter.visitMaxs(MethodWriter.java:1548)
	at org.objectweb.asm.MethodVisitor.visitMaxs(MethodVisitor.java:787)
	at org.objectweb.asm.tree.MethodNode.accept(MethodNode.java:767)
	at org.objectweb.asm.tree.MethodNode.accept(MethodNode.java:647)
	at org.objectweb.asm.tree.ClassNode.accept(ClassNode.java:468)
	at org.robolectric.internal.bytecode.ClassInstrumentor.instrumentToBytes(ClassInstrumentor.java:132)
	at org.robolectric.internal.bytecode.ClassInstrumentor.lambda$instrument$1(ClassInstrumentor.java:147)
	at org.robolectric.util.PerfStatsCollector.measure(PerfStatsCollector.java:52)
	at org.robolectric.internal.bytecode.ClassInstrumentor.instrument(ClassInstrumentor.java:147)
	at org.robolectric.internal.bytecode.SandboxClassLoader.maybeInstrumentClass(SandboxClassLoader.java:172)
	at org.robolectric.internal.bytecode.SandboxClassLoader.lambda$loadClass$0(SandboxClassLoader.java:155)
	at org.robolectric.util.PerfStatsCollector.measure(PerfStatsCollector.java:52)
	at org.robolectric.internal.bytecode.SandboxClassLoader.loadClass(SandboxClassLoader.java:155)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:502)
	at org.robolectric.Shadows.reset(Shadows.java:2808)
	at org.robolectric.android.internal.AndroidTestEnvironment.resetState(AndroidTestEnvironment.java:605)
	at org.robolectric.RobolectricTestRunner.lambda$finallyAfterTest$0(RobolectricTestRunner.java:351)
	at org.robolectric.util.PerfStatsCollector.measure(PerfStatsCollector.java:83)
	at org.robolectric.RobolectricTestRunner.finallyAfterTest(RobolectricTestRunner.java:349)
	at org.robolectric.internal.SandboxTestRunner.executeInSandbox(SandboxTestRunner.java:509)
	at org.robolectric.internal.SandboxTestRunner.access$900(SandboxTestRunner.java:67)
	at org.robolectric.internal.SandboxTestRunner$7.evaluate(SandboxTestRunner.java:442)
	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
	at org.robolectric.internal.SandboxTestRunner.access$600(SandboxTestRunner.java:67)
	at org.robolectric.internal.SandboxTestRunner$6.evaluate(SandboxTestRunner.java:333)
	at org.robolectric.internal.SandboxTestRunner$3.evaluate(SandboxTestRunner.java:233)
	at org.robolectric.internal.SandboxTestRunner$5.lambda$evaluate$0(SandboxTestRunner.java:317)
	at org.robolectric.internal.bytecode.Sandbox.lambda$runOnMainThread$0(Sandbox.java:101)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:330)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
	at java.base/java.lang.Thread.run(Thread.java:1516)
```

Until a new Robolectric version is released with ASM 9.9+ (https://asm.ow2.io/versions.html), we'll need to pin the asm version ourselves.