### PR TITLE
Upgrade to Android Gradle Plugin (AGP) 9.2.0

### DIFF
--- a/Sources/SkipUnit/Skip/skip.yml
+++ b/Sources/SkipUnit/Skip/skip.yml
@@ -43,12 +43,16 @@ settings:
                 # keep android-gradle-plugin and kotlin versions in sync according to compatibility table at
                 # https://developer.android.com/build/kotlin-support
 
-                - 'version("android-gradle-plugin", "8.13.2")'
+                - 'version("android-gradle-plugin", "9.2.0")'
                 - 'plugin("android-library", "com.android.library").versionRef("android-gradle-plugin")'
                 - 'plugin("android-application", "com.android.application").versionRef("android-gradle-plugin")'
 
                 - 'version("kotlin", "2.3.0")'
-                - 'plugin("kotlin-android", "org.jetbrains.kotlin.android").versionRef("kotlin")'
+
+                # AGP 9+ no longer needs (or supports) the org.jetbrains.kotlin.android plugin
+                # https://developer.android.com/build/migrate-to-built-in-kotlin#migration-steps-remove-kotlin-android-plugin
+                #- 'plugin("kotlin-android", "org.jetbrains.kotlin.android").versionRef("kotlin")'
+
                 - 'plugin("kotlin-compose", "org.jetbrains.kotlin.plugin.compose").versionRef("kotlin")'
                 - 'library("kotlin-bom", "org.jetbrains.kotlin", "kotlin-bom").versionRef("kotlin")'
 
@@ -84,7 +88,8 @@ build:
   contents:
     - block: 'plugins'
       contents:
-        - 'alias(libs.plugins.kotlin.android)'
+        # https://developer.android.com/build/migrate-to-built-in-kotlin#migration-steps-remove-kotlin-android-plugin
+        #- 'alias(libs.plugins.kotlin.android)'
         - 'alias(libs.plugins.android.library)'
         - 'id("maven-publish")'
 
@@ -107,7 +112,6 @@ build:
 
     - block: 'android'
       contents:
-        - 'namespace = group as String'
         - 'compileSdk = libs.versions.android.sdk.compile.get().toInt()'
         - block: 'defaultConfig'
           contents:


### PR DESCRIPTION
Paired with https://github.com/skiptools/skipstone/pull/253 and https://github.com/skiptools/skip/pull/697

See https://github.com/orgs/skiptools/discussions/698 for information on manual upgrade steps that will be needed.