### PR TITLE
Set merge mode for versionCatalog libs to enable overrides

### DIFF
--- a/Sources/SkipUnit/Skip/skip.yml
+++ b/Sources/SkipUnit/Skip/skip.yml
@@ -34,7 +34,12 @@ settings:
         # constants for the version dependencies
         - block: 'versionCatalogs'
           contents:
+            # `merge: prepend` makes a leaf module's `version("...")` / `library("...")` /
+            # `plugin("...")` entries emit before these defaults, so leaf overrides actually win
+            # in Gradle's version catalog DSL (where the first registration of an alias wins and
+            # later ones are silently ignored).
             - block: 'create("libs")'
+              merge: 'prepend'
               contents:
                 - 'version("jvm", "17")'
                 - 'version("android-sdk-min", "28")'
@@ -61,6 +66,7 @@ settings:
                 - 'library("kotlinx-coroutines-android", "org.jetbrains.kotlinx", "kotlinx-coroutines-android").versionRef("kotlin-coroutines")'
 
             - block: 'create("testLibs")'
+              merge: 'prepend'
               contents:
                 - 'version("androidx-test", "1.6.1")'
                 - 'library("androidx-test-runner", "androidx.test", "runner").versionRef("androidx-test")'


### PR DESCRIPTION
Due to https://github.com/gradle/gradle/issues/20836, trying to override a `versionCatalog` entry in module will fail. This prevents, e.g., an app from overriding the versions of compose libraries to use.

This PR takes advantage of the new `merge: 'prepend'` option added in  https://github.com/skiptools/skipstone/pull/254 to enable library versions to be overridden.