### PR TITLE
Bump android-sdk-compile from 36 to 37

### DIFF
--- a/Sources/SkipUnit/Skip/skip.yml
+++ b/Sources/SkipUnit/Skip/skip.yml
@@ -43,7 +43,7 @@ settings:
               contents:
                 - 'version("jvm", "17")'
                 - 'version("android-sdk-min", "28")'
-                - 'version("android-sdk-compile", "36")'
+                - 'version("android-sdk-compile", "37")'
 
                 # keep android-gradle-plugin and kotlin versions in sync according to compatibility table at
                 # https://developer.android.com/build/kotlin-support


### PR DESCRIPTION
CI failure is because Robolectric does not yet support Android SDK 37.

Marking this as a draft until Robolectric catches up.